### PR TITLE
Fix destination path for hasura-ndc-postgres on Windows.

### DIFF
--- a/plugins/ndc-postgres/v1.0.2/manifest.yaml
+++ b/plugins/ndc-postgres/v1.0.2/manifest.yaml
@@ -30,7 +30,7 @@ platforms:
     bin: hasura-ndc-postgres
     files:
       - from: ./ndc-postgres-cli-x86_64-pc-windows-msvc.exe
-        to: hasura-ndc-postgres
+        to: hasura-ndc-postgres.exe
   - selector: linux-amd64
     uri: https://github.com/hasura/ndc-postgres/releases/download/v1.0.2/ndc-postgres-cli-x86_64-unknown-linux-gnu
     sha256: c0ae9b40fdc909e2642c47784cdba618a1a6f7d6c7e2fecf32abc83bc28e8d7e

--- a/plugins/ndc-postgres/v1.1.0/manifest.yaml
+++ b/plugins/ndc-postgres/v1.1.0/manifest.yaml
@@ -30,7 +30,7 @@ platforms:
     bin: hasura-ndc-postgres
     files:
       - from: ./ndc-postgres-cli-x86_64-pc-windows-msvc.exe
-        to: hasura-ndc-postgres
+        to: hasura-ndc-postgres.exe
   - selector: linux-amd64
     uri: https://github.com/hasura/ndc-postgres/releases/download/v1.1.0/ndc-postgres-cli-x86_64-unknown-linux-gnu
     sha256: 82ef922647423c2378d51f8cbbff8baf885e213a9548f1ec71037a63e2918872


### PR DESCRIPTION
We were missing the ".exe" suffix.