### PR TITLE
ndc-go v1.10.0 and ndc-http v0.11.0

### DIFF
--- a/plugins/ndc-go/v1.10.0/manifest.yaml
+++ b/plugins/ndc-go/v1.10.0/manifest.yaml
@@ -1,0 +1,41 @@
+name: ndc-go
+version: "v1.10.0"
+shortDescription: "CLI plugin for Hasura ndc-go"
+homepage: https://github.com/hasura/ndc-sdk-go
+hidden: true
+platforms:
+  - selector: darwin-arm64
+    uri: "https://github.com/hasura/ndc-sdk-go/releases/download/v1.10.0/hasura-ndc-go-darwin-arm64"
+    sha256: "c38eb60c59bb4e1e8ecb51a0f9ee2efbbae4905d9ed13b7b836e89a156d5858a"
+    bin: "hasura-ndc-go"
+    files:
+      - from: "./hasura-ndc-go-darwin-arm64"
+        to: "hasura-ndc-go"
+  - selector: linux-arm64
+    uri: "https://github.com/hasura/ndc-sdk-go/releases/download/v1.10.0/hasura-ndc-go-linux-arm64"
+    sha256: "3f2236ada7b128e2efad2dda5680841bfaf44d23500d038ad006a7cf41a8a295"
+    bin: "hasura-ndc-go"
+    files:
+      - from: "./hasura-ndc-go-linux-arm64"
+        to: "hasura-ndc-go"
+  - selector: darwin-amd64
+    uri: "https://github.com/hasura/ndc-sdk-go/releases/download/v1.10.0/hasura-ndc-go-darwin-amd64"
+    sha256: "16eb88909a260d646b43830efe80ecfff0852a92972f70cf13722b7c768b1f9a"
+    bin: "hasura-ndc-go"
+    files:
+      - from: "./hasura-ndc-go-darwin-amd64"
+        to: "hasura-ndc-go"
+  - selector: windows-amd64
+    uri: "https://github.com/hasura/ndc-sdk-go/releases/download/v1.10.0/hasura-ndc-go-windows-amd64.exe"
+    sha256: "b4ef9ab32db3621ba7981ba23ee07ffbbd17db71db4c43c8deac376a77d95f3c"
+    bin: "hasura-ndc-go.exe"
+    files:
+      - from: "./hasura-ndc-go-windows-amd64.exe"
+        to: "hasura-ndc-go.exe"
+  - selector: linux-amd64
+    uri: "https://github.com/hasura/ndc-sdk-go/releases/download/v1.10.0/hasura-ndc-go-linux-amd64"
+    sha256: "a19b5e412e827fefb5e23032f3093165fd96857712cf97fbd4c015b31cc2247c"
+    bin: "hasura-ndc-go"
+    files:
+      - from: "./hasura-ndc-go-linux-amd64"
+        to: "hasura-ndc-go"

--- a/plugins/ndc-http/v0.11.0/manifest.yaml
+++ b/plugins/ndc-http/v0.11.0/manifest.yaml
@@ -1,0 +1,41 @@
+name: ndc-http
+version: "v0.11.0"
+shortDescription: "CLI plugin for Hasura HTTP data connector"
+homepage: https://github.com/hasura/ndc-http
+hidden: true
+platforms:
+  - selector: darwin-arm64
+    uri: "https://github.com/hasura/ndc-http/releases/download/v0.11.0/ndc-http-schema-darwin-arm64"
+    sha256: "2681709d1fbe8614bbeebaf05dc3d0bc48ef5596b8b17caa8db6127f3cf6f078"
+    bin: "hasura-ndc-http"
+    files:
+      - from: "./ndc-http-schema-darwin-arm64"
+        to: "hasura-ndc-http"
+  - selector: linux-arm64
+    uri: "https://github.com/hasura/ndc-http/releases/download/v0.11.0/ndc-http-schema-linux-arm64"
+    sha256: "512a1ab45842c5c2f3bed903c4b1805c220c5d6eba85bdbde0a7f2035a6c1413"
+    bin: "hasura-ndc-http"
+    files:
+      - from: "./ndc-http-schema-linux-arm64"
+        to: "hasura-ndc-http"
+  - selector: darwin-amd64
+    uri: "https://github.com/hasura/ndc-http/releases/download/v0.11.0/ndc-http-schema-darwin-amd64"
+    sha256: "1c993b024abc9f15230aeed8d70ed5a492715efdd423d9295bcba1fb7e7adc5f"
+    bin: "hasura-ndc-http"
+    files:
+      - from: "./ndc-http-schema-darwin-amd64"
+        to: "hasura-ndc-http"
+  - selector: windows-amd64
+    uri: "https://github.com/hasura/ndc-http/releases/download/v0.11.0/ndc-http-schema-windows-amd64.exe"
+    sha256: "bad35d4785903a7c560a51c9778e44d44ebcb0b44890eac59ae9bca4dc3181b8"
+    bin: "hasura-ndc-http.exe"
+    files:
+      - from: "./ndc-http-schema-windows-amd64.exe"
+        to: "hasura-ndc-http.exe"
+  - selector: linux-amd64
+    uri: "https://github.com/hasura/ndc-http/releases/download/v0.11.0/ndc-http-schema-linux-amd64"
+    sha256: "c91044247d08df934bb44684ec042f18e11849e6164345ef23b8042e10f1e4d6"
+    bin: "hasura-ndc-http"
+    files:
+      - from: "./ndc-http-schema-linux-amd64"
+        to: "hasura-ndc-http"


### PR DESCRIPTION
This pull request introduces two new CLI plugins, `ndc-go` and `ndc-http`, with their respective manifests. These plugins provide platform-specific binaries for various architectures and operating systems. Below are the key changes:

### Addition of `ndc-go` plugin:
* A new manifest file `plugins/ndc-go/v1.10.0/manifest.yaml` was added for the `ndc-go` CLI plugin, version `v1.10.0`. It includes platform-specific binaries for `darwin-arm64`, `darwin-amd64`, `linux-arm64`, `linux-amd64`, and `windows-amd64`.

### Addition of `ndc-http` plugin:
* A new manifest file `plugins/ndc-http/v0.11.0/manifest.yaml` was added for the `ndc-http` CLI plugin, version `v0.11.0`. It includes platform-specific binaries for `darwin-arm64`, `darwin-amd64`, `linux-arm64`, `linux-amd64`, and `windows-amd64`.