### PR TITLE
ndc-prometheus v0.4.1

### DIFF
--- a/plugins/ndc-prometheus/v0.4.1/manifest.yaml
+++ b/plugins/ndc-prometheus/v0.4.1/manifest.yaml
@@ -1,0 +1,41 @@
+name: ndc-prometheus
+version: "v0.4.1"
+shortDescription: "CLI plugin for Hasura Prometheus data connector"
+homepage: https://github.com/hasura/ndc-prometheus
+hidden: true
+platforms:
+  - selector: darwin-arm64
+    uri: "https://github.com/hasura/ndc-prometheus/releases/download/v0.4.1/ndc-prometheus-darwin-arm64"
+    sha256: "dde17612610657c6d11f9e4f759261c87a316e72edb64f7888815aeb09f5d076"
+    bin: "ndc-prometheus"
+    files:
+      - from: "./ndc-prometheus-darwin-arm64"
+        to: "ndc-prometheus"
+  - selector: linux-arm64
+    uri: "https://github.com/hasura/ndc-prometheus/releases/download/v0.4.1/ndc-prometheus-linux-arm64"
+    sha256: "8afaa588d4ac18b7bd99a3ccb3bda14e4877990db1c834fb794bd8d4a8dcd2ca"
+    bin: "ndc-prometheus"
+    files:
+      - from: "./ndc-prometheus-linux-arm64"
+        to: "ndc-prometheus"
+  - selector: darwin-amd64
+    uri: "https://github.com/hasura/ndc-prometheus/releases/download/v0.4.1/ndc-prometheus-darwin-amd64"
+    sha256: "d91d56807b0fb736ba9d3880c8a3542e376c91c27e326b22f0cc7383b19e11c4"
+    bin: "ndc-prometheus"
+    files:
+      - from: "./ndc-prometheus-darwin-amd64"
+        to: "ndc-prometheus"
+  - selector: windows-amd64
+    uri: "https://github.com/hasura/ndc-prometheus/releases/download/v0.4.1/ndc-prometheus-windows-amd64.exe"
+    sha256: "60df4c900c5500ad83fd743455e9278301acdd1adf7f9865621e3894d7ff1cf9"
+    bin: "ndc-prometheus.exe"
+    files:
+      - from: "./ndc-prometheus-windows-amd64.exe"
+        to: "ndc-prometheus.exe"
+  - selector: linux-amd64
+    uri: "https://github.com/hasura/ndc-prometheus/releases/download/v0.4.1/ndc-prometheus-linux-amd64"
+    sha256: "c23850d710814b6d9de754ae154abed6a02fe123c1de328f4f29bb530173d755"
+    bin: "ndc-prometheus"
+    files:
+      - from: "./ndc-prometheus-linux-amd64"
+        to: "ndc-prometheus"


### PR DESCRIPTION
This pull request adds a new manifest file for the `ndc-prometheus` CLI plugin, which is a data connector for Hasura Prometheus. The manifest specifies metadata, platform-specific binaries, and file mappings for version `v0.4.1`.

### Manifest additions:

* [`plugins/ndc-prometheus/v0.4.1/manifest.yaml`](diffhunk://#diff-711b1fd45e4e978538ff63fceaece96c498c166b8ac0d04ca1a93f044d0fe87eR1-R41): Introduced the `ndc-prometheus` plugin with metadata including name, version, description, homepage, and visibility settings.
* [`plugins/ndc-prometheus/v0.4.1/manifest.yaml`](diffhunk://#diff-711b1fd45e4e978538ff63fceaece96c498c166b8ac0d04ca1a93f044d0fe87eR1-R41): Defined platform-specific binaries for `darwin-arm64`, `linux-arm64`, `darwin-amd64`, `windows-amd64`, and `linux-amd64`, including their URIs, SHA256 checksums, and file mappings.