### PR TITLE
Release ndc-go v2.3.0, ndc-http v0.14.0, elasticsearch v1.10.0

### DIFF
--- a/plugins/elasticsearch/v1.10.0/manifest.yaml
+++ b/plugins/elasticsearch/v1.10.0/manifest.yaml
@@ -1,0 +1,41 @@
+name: elasticsearch
+version: "v1.10.0"
+shortDescription: "CLI plugin for Hasura ndc-elasticsearch"
+homepage: https://hasura.io/connectors/elasticsearch
+hidden: true
+platforms:
+  - selector: darwin-arm64
+    uri: "https://github.com/hasura/ndc-elasticsearch/releases/download/v1.10.0/ndc-elasticsearch-cli-aarch64-apple-darwin"
+    sha256: "8e8bdd55a978410b60d69a3b827a09b12b42e4cb945d8c0dad27ab0e357cb2e2"
+    bin: "hasura-elasticsearch"
+    files:
+      - from: "./ndc-elasticsearch-cli-aarch64-apple-darwin"
+        to: "hasura-elasticsearch"
+  - selector: linux-arm64
+    uri: "https://github.com/hasura/ndc-elasticsearch/releases/download/v1.10.0/ndc-elasticsearch-cli-aarch64-unknown-linux-musl"
+    sha256: "63e363bbac09ecbf735368864998f6538c77d388f57b2173236e0ecc65d34ba4"
+    bin: "hasura-elasticsearch"
+    files:
+      - from: "./ndc-elasticsearch-cli-aarch64-unknown-linux-musl"
+        to: "hasura-elasticsearch"
+  - selector: darwin-amd64
+    uri: "https://github.com/hasura/ndc-elasticsearch/releases/download/v1.10.0/ndc-elasticsearch-cli-x86_64-apple-darwin"
+    sha256: "2c430988c10262b0805e3700ae3acc63095a233cdb80ea1b7a4d74d4a1a96c9c"
+    bin: "hasura-elasticsearch"
+    files:
+      - from: "./ndc-elasticsearch-cli-x86_64-apple-darwin"
+        to: "hasura-elasticsearch"
+  - selector: windows-amd64
+    uri: "https://github.com/hasura/ndc-elasticsearch/releases/download/v1.10.0/ndc-elasticsearch-cli-x86_64-pc-windows-msvc.exe"
+    sha256: "cea742cfd568eea226eb58c77b8728f1fcde2bf0ecbf15820409b37d437911eb"
+    bin: "hasura-elasticsearch.exe"
+    files:
+      - from: "./ndc-elasticsearch-cli-x86_64-pc-windows-msvc.exe"
+        to: "hasura-elasticsearch.exe"
+  - selector: linux-amd64
+    uri: "https://github.com/hasura/ndc-elasticsearch/releases/download/v1.10.0/ndc-elasticsearch-cli-x86_64-unknown-linux-musl"
+    sha256: "59550ac8c23f1bc2d028b8c4ae94f0f38a62596b51fb53ef647aba6ea15e5f6c"
+    bin: "hasura-elasticsearch"
+    files:
+      - from: "./ndc-elasticsearch-cli-x86_64-unknown-linux-musl"
+        to: "hasura-elasticsearch"

--- a/plugins/ndc-go/v2.3.0/manifest.yaml
+++ b/plugins/ndc-go/v2.3.0/manifest.yaml
@@ -1,0 +1,41 @@
+name: ndc-go
+version: "v2.3.0"
+shortDescription: "CLI plugin for Hasura ndc-go"
+homepage: https://github.com/hasura/ndc-sdk-go
+hidden: true
+platforms:
+  - selector: darwin-arm64
+    uri: "https://github.com/hasura/ndc-sdk-go/releases/download/v2.3.0/hasura-ndc-go-darwin-arm64"
+    sha256: "7741d2e0766725cb1e8c1540e1536106aec136cb3797aaaa16368e40fd5c114b"
+    bin: "hasura-ndc-go"
+    files:
+      - from: "./hasura-ndc-go-darwin-arm64"
+        to: "hasura-ndc-go"
+  - selector: linux-arm64
+    uri: "https://github.com/hasura/ndc-sdk-go/releases/download/v2.3.0/hasura-ndc-go-linux-arm64"
+    sha256: "a52f8be8a56e7f9940b6bfdf431af48d05ce8fee12af0c1deaf5fd2bdfa15a73"
+    bin: "hasura-ndc-go"
+    files:
+      - from: "./hasura-ndc-go-linux-arm64"
+        to: "hasura-ndc-go"
+  - selector: darwin-amd64
+    uri: "https://github.com/hasura/ndc-sdk-go/releases/download/v2.3.0/hasura-ndc-go-darwin-amd64"
+    sha256: "e3fbf18cca719ae439383d1f2955b21463182f02398e833e671f2ab24eea6f13"
+    bin: "hasura-ndc-go"
+    files:
+      - from: "./hasura-ndc-go-darwin-amd64"
+        to: "hasura-ndc-go"
+  - selector: windows-amd64
+    uri: "https://github.com/hasura/ndc-sdk-go/releases/download/v2.3.0/hasura-ndc-go-windows-amd64.exe"
+    sha256: "aa8bc890a377acb7ff05f35581bb2007a92225006619b523f14fdc565305a3d8"
+    bin: "hasura-ndc-go.exe"
+    files:
+      - from: "./hasura-ndc-go-windows-amd64.exe"
+        to: "hasura-ndc-go.exe"
+  - selector: linux-amd64
+    uri: "https://github.com/hasura/ndc-sdk-go/releases/download/v2.3.0/hasura-ndc-go-linux-amd64"
+    sha256: "8ea85e48ef4d78f9a86a225d3717457cf8e38e2174b4eb73c00569b8d81e5337"
+    bin: "hasura-ndc-go"
+    files:
+      - from: "./hasura-ndc-go-linux-amd64"
+        to: "hasura-ndc-go"

--- a/plugins/ndc-http/v0.14.0/manifest.yaml
+++ b/plugins/ndc-http/v0.14.0/manifest.yaml
@@ -1,0 +1,41 @@
+name: ndc-http
+version: "v0.14.0"
+shortDescription: "CLI plugin for Hasura HTTP data connector"
+homepage: https://github.com/hasura/ndc-http
+hidden: true
+platforms:
+  - selector: darwin-arm64
+    uri: "https://github.com/hasura/ndc-http/releases/download/v0.14.0/ndc-http-schema-darwin-arm64"
+    sha256: "5f530118d77f06b39a1f5d9c8ecacebc0ae5e5db4a79639471d2e6c37da92f51"
+    bin: "hasura-ndc-http"
+    files:
+      - from: "./ndc-http-schema-darwin-arm64"
+        to: "hasura-ndc-http"
+  - selector: linux-arm64
+    uri: "https://github.com/hasura/ndc-http/releases/download/v0.14.0/ndc-http-schema-linux-arm64"
+    sha256: "e516fb8c2af18042b77422565fdcc8e49eae3004c57a975a867332581e13eb29"
+    bin: "hasura-ndc-http"
+    files:
+      - from: "./ndc-http-schema-linux-arm64"
+        to: "hasura-ndc-http"
+  - selector: darwin-amd64
+    uri: "https://github.com/hasura/ndc-http/releases/download/v0.14.0/ndc-http-schema-darwin-amd64"
+    sha256: "b99718e943a12154ebf70685e45938549a988e3da19e8d50735937f0870a9b09"
+    bin: "hasura-ndc-http"
+    files:
+      - from: "./ndc-http-schema-darwin-amd64"
+        to: "hasura-ndc-http"
+  - selector: windows-amd64
+    uri: "https://github.com/hasura/ndc-http/releases/download/v0.14.0/ndc-http-schema-windows-amd64.exe"
+    sha256: "62e349d222ee1398f09fb1d9051600e2f690899250fa3a6cbe8dbcd574abea78"
+    bin: "hasura-ndc-http.exe"
+    files:
+      - from: "./ndc-http-schema-windows-amd64.exe"
+        to: "hasura-ndc-http.exe"
+  - selector: linux-amd64
+    uri: "https://github.com/hasura/ndc-http/releases/download/v0.14.0/ndc-http-schema-linux-amd64"
+    sha256: "1156e5b07ef21f9171683027f0f5de3c2c806aaefcb20f5d60f8d163346ba21e"
+    bin: "hasura-ndc-http"
+    files:
+      - from: "./ndc-http-schema-linux-amd64"
+        to: "hasura-ndc-http"


### PR DESCRIPTION
This pull request adds new CLI plugin manifests for three different Hasura data connectors, each at a new version. These manifests define how to install the plugins across major platforms and provide the necessary metadata for each plugin.

New plugin manifests added:

**Elasticsearch Connector:**
- Added manifest for the `elasticsearch` CLI plugin version `v1.10.0`, including download URIs, checksums, and binaries for Darwin, Linux, and Windows (both ARM64 and AMD64 architectures). (`plugins/elasticsearch/v1.10.0/manifest.yaml`)

**Go Data Connector:**
- Added manifest for the `ndc-go` CLI plugin version `v2.3.0`, supporting all major platforms and architectures, with appropriate download links and checksums. (`plugins/ndc-go/v2.3.0/manifest.yaml`)

**HTTP Data Connector:**
- Added manifest for the `ndc-http` CLI plugin version `v0.14.0`, providing cross-platform support and specifying all required binary and file mappings. (`plugins/ndc-http/v0.14.0/manifest.yaml`)